### PR TITLE
apiUpdate1

### DIFF
--- a/src/js/api-connect.js
+++ b/src/js/api-connect.js
@@ -1,5 +1,8 @@
 const API_KEY = 'Ci1vLtAQ5toUQm0alN6gL6AfnGn8TpWy';
 const BASE_URL = 'https://app.ticketmaster.com/discovery/v2/events.json?';
+let arr = [];
+let currentPage = 0;
+
 
 export default async function connect(keyword = '', page = 0, size = 20, countryCode = '') {
 
@@ -7,7 +10,29 @@ export default async function connect(keyword = '', page = 0, size = 20, country
         const promiseResponse = await fetch(`${BASE_URL}classificationName=music&apikey=${API_KEY}&keyword=${keyword}&page=${page}&size=${size}&countryCode=${countryCode}`);
         const data = await promiseResponse.json();
 
-        return data;
+        // return data;
+
+        if (data.page.totalPages > 1) {   
+        for (let i = 0; i < 4; i++) {
+        const promiseResponse = await fetch(`${BASE_URL}classificationName=music&dmaId=324&apikey=${API_KEY}&keyword=${keyword}&page=${currentPage}&size=${size}&countryCode=${countryCode}`);
+        const data = await promiseResponse.json();
+            arr.push(...data._embedded.events);
+            ++currentPage;
+            }
+            
+            // console.log(`${keyword} ` , arr);
+            currentPage = 0;
+
+            return data;
+    }
+
+        
+        else {
+            return data;
+        }
+
+
+
     }
     catch (err) {
         console.log(err);
@@ -22,4 +47,7 @@ export default async function connect(keyword = '', page = 0, size = 20, country
 const obj = connect('', 0, 20, '');
 
 obj.then(log => console.log(log));
+
+
+
 


### PR DESCRIPTION
Добавил выгрузку  коллекции из 4 элементов, необходимо проверить как будут рендериться карточки с таким вариантом.
Т.е. теперь api-connect возвращает коллекцию из 80 элементов.

Можно увеличить выборку, но осторожно, АПИ сервис может блокировать частые запросы. 
В этой строке   for (let i = 0; i < 4; i++) { можно вместо 4 поставить data.page.totalPages, чтобы грузились все найденные страницы.